### PR TITLE
도서 단일/목록 조회 썸네일 도메인 url 매핑 추가, 도서 수정로직 일부수정

### DIFF
--- a/src/main/java/com/deokhugam/domain/book/mapper/BookThumbnailUrlResolver.java
+++ b/src/main/java/com/deokhugam/domain/book/mapper/BookThumbnailUrlResolver.java
@@ -1,0 +1,23 @@
+package com.deokhugam.domain.book.mapper;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookThumbnailUrlResolver {
+    private final String cloudFrontDomain;
+
+    public BookThumbnailUrlResolver(@Value("${storage.app.aws.cloud-front.domain}") String cloudFrontDomain) {
+        this.cloudFrontDomain = trimTrailingSlash(cloudFrontDomain);
+    }
+
+    public String toFullUrl(String key) {
+        if (key == null || key.isBlank()) return null;
+        if (key.startsWith("http://") || key.startsWith("https://")) return key;
+        return cloudFrontDomain + "/" + key;
+    }
+
+    private static String trimTrailingSlash(String s) {
+        return (s != null && s.endsWith("/")) ? s.substring(0, s.length() - 1) : s;
+    }
+}

--- a/src/main/java/com/deokhugam/domain/book/mapper/BookThumbnailUrlResolver.java
+++ b/src/main/java/com/deokhugam/domain/book/mapper/BookThumbnailUrlResolver.java
@@ -17,7 +17,7 @@ public class BookThumbnailUrlResolver {
         return cloudFrontDomain + "/" + key;
     }
 
-    private static String trimTrailingSlash(String s) {
-        return (s != null && s.endsWith("/")) ? s.substring(0, s.length() - 1) : s;
+    private static String trimTrailingSlash(String url) {
+        return (url != null && url.endsWith("/")) ? url.substring(0, url.length() - 1) : url;
     }
 }

--- a/src/main/java/com/deokhugam/domain/book/mapper/BookUrlMapper.java
+++ b/src/main/java/com/deokhugam/domain/book/mapper/BookUrlMapper.java
@@ -1,0 +1,38 @@
+package com.deokhugam.domain.book.mapper;
+
+import com.deokhugam.domain.book.dto.response.BookDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BookUrlMapper {
+    private final BookThumbnailUrlResolver thumbnailUrlResolver;
+
+    public BookDto withFullThumbnailUrl(BookDto bookDto) {
+        String fullUrl = thumbnailUrlResolver.toFullUrl(bookDto.thumbnailUrl());
+        return new BookDto(
+                bookDto.id(),
+                bookDto.title(),
+                bookDto.author(),
+                bookDto.description(),
+                bookDto.publisher(),
+                bookDto.publishedDate(),
+                bookDto.isbn(),
+                fullUrl,
+                bookDto.reviewCount(),
+                bookDto.rating(),
+                bookDto.createdAt(),
+                bookDto.updatedAt()
+        );
+    }
+
+    public List<BookDto> withFullThumbnailUrl(List<BookDto> list) {
+        return list.stream().map(this::withFullThumbnailUrl).toList();
+    }
+}
+
+
+

--- a/src/main/java/com/deokhugam/domain/book/service/BookServiceImpl.java
+++ b/src/main/java/com/deokhugam/domain/book/service/BookServiceImpl.java
@@ -12,10 +12,11 @@ import com.deokhugam.domain.book.entity.Book;
 import com.deokhugam.domain.book.exception.BookException;
 import com.deokhugam.domain.book.exception.BookNotFoundException;
 import com.deokhugam.domain.book.mapper.BookMapper;
+import com.deokhugam.domain.book.mapper.BookUrlMapper;
 import com.deokhugam.domain.book.repository.BookRepository;
+import com.deokhugam.global.exception.ErrorCode;
 import com.deokhugam.infrastructure.search.book.BookApiManager;
 import com.deokhugam.infrastructure.search.book.dto.BookGlobalApiDto;
-import com.deokhugam.global.exception.ErrorCode;
 import com.deokhugam.infrastructure.storage.FileStorage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,13 +40,15 @@ public class BookServiceImpl implements BookService {
     private final BookRepository bookRepository;
     private final FileStorage fileStorage;
     private final BookApiManager bookApiManager;
+    private final BookUrlMapper bookUrlMapper;
 
 
     @Override
     @Transactional(readOnly = true)
     public BookDto getBookDetail(UUID bookId) {
-        return bookRepository.findBookDetailById(bookId)
+        BookDto bookDto = bookRepository.findBookDetailById(bookId)
                 .orElseThrow(() -> new BookNotFoundException(ErrorCode.BOOK_NOT_FOUND));
+        return bookUrlMapper.withFullThumbnailUrl(bookDto);
     }
 
     @Override
@@ -53,7 +56,7 @@ public class BookServiceImpl implements BookService {
     public CursorPageResponseBookDto searchBooks(BookSearchCondition bookSearchCondition) {
         Pageable pageable = PageRequest.of(0, bookSearchCondition.limit());
         Page<BookDto> pageBook = bookRepository.findBooks(bookSearchCondition, pageable);
-        List<BookDto> content = pageBook.getContent();
+        List<BookDto> content = bookUrlMapper.withFullThumbnailUrl(pageBook.getContent());
         BookDto last = content.isEmpty() ? null : content.get(content.size() - 1);
         String nextCursor = null;
         Instant nextAfter = null;
@@ -151,7 +154,7 @@ public class BookServiceImpl implements BookService {
         String newKey = null;
         String oldKeyToDelete = null;
 
-        if (existingBook.isDeleted()){
+        if (existingBook.isDeleted()) {
             throw new BookNotFoundException(ErrorCode.BOOK_NOT_FOUND);
         }
 
@@ -181,7 +184,9 @@ public class BookServiceImpl implements BookService {
         String cdnUrl = fileStorage.generateUrl(existingBook.getThumbnailUrl());
         log.info("책 수정 완료 - ID: {}", existingBook.getId());
 
-        BookDto dto = getBookDetail(bookId);
+//        BookDto dto = getBookDetail(bookId); // TODO: 같은 서비스 메서드 연동해서 사용하면 의존성이 생기고 해당 서비스 메서드 로직 바뀔시 동작 안할수있기때문에 개별로 레포지토리 요청할것(update서비스에서 thumbnail 매핑하는데 단일 레포에서도 해야하기떄문에 이렇게 중복사용시 사이드이팩 생길여부 생김) 또한 사용자 요청을 위한 메서드호출이지 내부 로직을 위한 메서드가 아니라 응용하지말것, 테스트코드에서 이부분 update할떄 의존하는부분 문제로 캐치했었음, by 태언
+        BookDto dto = bookRepository.findBookDetailById(bookId) // TODO: 성연님 부재중이라 기존 테스트코드 그대로 가져가기위해 임시로 수정, 성연님께 피드백후 해당부분 사용 여부 결정하시도록 전달 By 태언
+                .orElseThrow(() -> new BookNotFoundException(ErrorCode.BOOK_NOT_FOUND));
         return BookMapper.toDto(existingBook, cdnUrl, dto.reviewCount(), dto.rating());
     }
 


### PR DESCRIPTION
- BookThumbnailUrlResolver와 BookUrlMapper를 사용해 썸네일 URL 생성 로직 구현
- BookServiceImpl에 URL 매핑 로직 적용
- 기존 동작 보장을 위한 테스트 코드 수정 및 추가

## PR 타입

- [ ] Feat: 새로운 기능 추가
- [ ] Add : 새로운 파일/내용 추가
- [ ] Bug : 버그 발견
- [x] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] Refactor : 코드 리펙토링


## 변경사항

- 도서 단일/목록 조회시 thumbnail Path만 된부분 cloudfront 도메인 붙이는 매핑되는 구조로 변경
- 도서 수정 기능에서 단일 조회 메서드 의존하는 부분 레포 요청으로 수정
